### PR TITLE
Fix argument order in Spanish step definition

### DIFF
--- a/cypress/common/stepDefinition.core.js
+++ b/cypress/common/stepDefinition.core.js
@@ -31,7 +31,7 @@ When('una petición {word} es enviada al endpoint {string}', (method, endPoint, 
     pageObject.sendRequest(method, endPoint, settings);
 });
 
-When(/^se muestre la (petición|respuesta) de "([^"]*)"?$/, (endPoint, type) => {
+When(/^se muestre la (petición|respuesta) de "([^"]*)"?$/, (type, endPoint) => {
     pageObject._showManager(type, endPoint);
 });
 


### PR DESCRIPTION
## Summary
- fix parameter order in Spanish API steps

## Testing
- `npm test` *(fails: missing script)*
- `npx cypress verify` *(fails: network access)*

------
https://chatgpt.com/codex/tasks/task_e_683fa142562083239393aff6da11494e